### PR TITLE
Clarify criteria

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
       <ul>
         <li>Above
         <li>Initial spec text
+        <li>Identify designated reviewers
       </ul>
     </td>
     <td>The committee expects the feature to be developed and eventually included in the standard
@@ -155,7 +156,7 @@
 
 <h2>Reviewers</h2>
 
-<p>Anyone can be a reviewer and submit feedback on an in-process addition. The committee may identify designated reviewers for acceptance at the “candidate” maturity stage. Designated reviewers should not be authors of the spec text for the addition and should have expertise applicable to the subject matter.
+<p>Anyone can be a reviewer and submit feedback on an in-process addition. The committee must identify designated reviewers for acceptance before a proposal enters the “draft” (stage 2) maturity stage. These reviewers must give their sign-off before a proposal enters the “candidate” (stage 3) maturity stage. Designated reviewers should not be authors of the spec text for the addition and should have expertise applicable to the subject matter.
 
 <h2>Eliding the process</h2>
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       <th>
       <th>Stage
       <th>Purpose
-      <th>Criteria
+      <th>Entrance Criteria
       <th>Acceptance Signifies
       <th>Spec Quality
       <th>Post-Acceptance Changes Expected


### PR DESCRIPTION
The main item here is to clarify that these are entrance criteria, not exit criteria.

If someone believes otherwise, it would be great if they could pull up minutes from previous meetings to support this.
