### PR TITLE
Implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       <th>Acceptance Signifies
       <th>Spec Quality
       <th>Post-Acceptance Changes Expected
-      <th>Implementation Types Expected
+      <th>Implementations Expected During This Stage
     </tr>
   </thead>
   <tr>
@@ -91,12 +91,13 @@
         <li>Above
         <li>Initial spec text
         <li>Identify designated reviewers
+        <li>Polyfill or transpiler implementations
       </ul>
     </td>
     <td>The committee expects the feature to be developed and eventually included in the standard
     <td>Draft: all <em>major</em> semantics, syntax and API are covered, but TODOs, placeholders and editorial issues are expected
     <td>Incremental
-    <td>Experimental, in a major browser VM
+    <td>Experimental, in major browser VMs
   </tr>
   <tr>
     <td>3
@@ -108,12 +109,13 @@
         <li>Complete spec text
         <li>Designated reviewers have signed off on the current spec text
         <li>The ECMAScript editor has signed off on the current spec text
+        <li>Experimental implementations committed to two major browser VMs
       </ul>
     </td>
     <td>The solution is complete and no further work is possible without implementation experience, significant usage and external feedback.
     <td>Complete: all semantics, syntax and API are completed described
     <td>Limited: only those deemed critical based on implementation experience
-    <td>Spec compliant, in a major browser VM
+    <td>Spec compliant and shipping without a flag, in two major browser VMs
   </tr>
   <tr>
     <td>4
@@ -125,12 +127,13 @@
         <li>Test 262 acceptance tests have been written for mainline usage scenarios
         <li>Two compatible implementations which pass the acceptance tests
         <li>The ECMAScript editor has signed off on the current spec text
+        <li>Shipping, spec-compliant implementations committed to two major browser VMs
       </ul>
     </td>
     <td>The addition will be included in the soonest practical standard revision
     <td>Final: All changes as a result of implementation experience are integrated
     <td>None
-    <td>Shipping, in major browser VMs
+    <td>N/A
   </tr>
 </table>
 

--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
       <ul>
         <li>Above
         <li>Initial spec text
+        <li>Identify designated reviewers
       </ul>
     </td>
     <td>The committee expects the feature to be developed and eventually included in the standard
@@ -155,7 +156,7 @@
 
 <h2>Reviewers</h2>
 
-<p>Anyone can be a reviewer and submit feedback on an in-process addition. The committee may identify designated reviewers for acceptance at the “candidate” maturity stage. Designated reviewers should not be authors of the spec text for the addition and should have expertise applicable to the subject matter.
+<p>Anyone can be a reviewer and submit feedback on an in-process addition. The committee must identify designated reviewers for acceptance before a proposal enters the “draft” (stage 2) maturity stage. These reviewers must give their sign-off before a proposal enters the “candidate” (stage 3) maturity stage. Designated reviewers should not be authors of the spec text for the addition and should have expertise applicable to the subject matter.
 
 <h2>Eliding the process</h2>
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       <th>
       <th>Stage
       <th>Purpose
-      <th>Criteria
+      <th>Entrance Criteria
       <th>Acceptance Signifies
       <th>Spec Quality
       <th>Post-Acceptance Changes Expected

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     </td>
     <td>None
     <td>Major
-    <td>Polyfills / demos
+    <td>Polyfills, transpilers, and demos
   </tr>
   <tr>
     <td>2
@@ -96,7 +96,7 @@
     <td>The committee expects the feature to be developed and eventually included in the standard
     <td>Draft: all <em>major</em> semantics, syntax and API are covered, but TODOs, placeholders and editorial issues are expected
     <td>Incremental
-    <td>Experimental
+    <td>Experimental, in a major browser VM
   </tr>
   <tr>
     <td>3
@@ -113,7 +113,7 @@
     <td>The solution is complete and no further work is possible without implementation experience, significant usage and external feedback.
     <td>Complete: all semantics, syntax and API are completed described
     <td>Limited: only those deemed critical based on implementation experience
-    <td>Spec compliant
+    <td>Spec compliant, in a major browser VM
   </tr>
   <tr>
     <td>4
@@ -130,7 +130,7 @@
     <td>The addition will be included in the soonest practical standard revision
     <td>Final: All changes as a result of implementation experience are integrated
     <td>None
-    <td>Shipping
+    <td>Shipping, in major browser VMs
   </tr>
 </table>
 


### PR DESCRIPTION
Builds on #1.
- Clarifies polyfills/transpilers vs. major browser VMs (a term left undefined for now...)
- Clarifies the "implementations expected" column, by changing the heading and also including it in the entrance criteria.
