### PR TITLE
Reviewer feedback deadline

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,8 @@
 
 <p>Anyone can be a reviewer and submit feedback on an in-process addition. The committee should identify designated reviewers for acceptance during the “draft” (stage 2) maturity stage. These reviewers must give their sign-off before a proposal enters the “candidate” (stage 3) maturity stage. Designated reviewers should not be authors of the spec text for the addition and should have expertise applicable to the subject matter. Designated reviewers must be chosen by the committee, not by the proposal's champion.
 
+<p>When reviewers are designated, a target meeting for Stage 3 should be identified. Initial reviewer feedback should be given to the champions one month before that meeting to allow for a back-and-forth ahead of the meeting. The target Stage 3 meeting may be delayed by a champion outside of the meeting at a later time if it is not ready.
+
 <h2>Eliding the process</h2>
 
 <p>The committee may elide the process based on the scope of a change under consideration as it sees fit.

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 
 <p>Anyone can be a reviewer and submit feedback on an in-process addition. The committee should identify designated reviewers for acceptance during the “draft” (stage 2) maturity stage. These reviewers must give their sign-off before a proposal enters the “candidate” (stage 3) maturity stage. Designated reviewers should not be authors of the spec text for the addition and should have expertise applicable to the subject matter. Designated reviewers must be chosen by the committee, not by the proposal's champion.
 
-<p>When reviewers are designated, a target meeting for Stage 3 should be identified. Initial reviewer feedback should be given to the champions one month before that meeting to allow for a back-and-forth ahead of the meeting. The target Stage 3 meeting may be delayed by a champion outside of the meeting at a later time if it is not ready.
+<p>When reviewers are designated, a target meeting for Stage 3 should be identified. Initial reviewer feedback should be given to the champions two weeks before that meeting to allow for a back-and-forth ahead of the meeting. The target Stage 3 meeting may be delayed by a champion outside of the meeting at a later time if it is not ready.
 
 <h2>Eliding the process</h2>
 


### PR DESCRIPTION
Reviewers should provide feedback a month before the meeting where
the proposal is up for Stage 3 review.
