### PR TITLE
Clarify seemingly redundant criterium

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
         <li><a href="https://github.com/tc39/test262">Test262</a> acceptance tests have been written for mainline usage scenarios, and merged
         <li>Two compatible implementations which pass the acceptance tests
         <li>Significant in-the-field experience with shipping implementations, such as that provided by two independent VMs
-        <li>The ECMAScript editor has signed off on the current spec text
+        <li>The ECMAScript editor has signed off on the final spec text
       </ul>
     </td>
     <td>The addition will be included in the soonest practical standard revision


### PR DESCRIPTION
“The ECMAScript editor has signed off on the current spec text” is already a requirement for stage 3 and is thus covered by the “Above” criterium in stage 4.
