### PR TITLE
Add Stage 3.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,13 +115,29 @@
     <td>Spec compliant
   </tr>
   <tr>
+    <td>3.5
+    <td>Advanced candidate
+    <td>Significant refinement has come from some implementation experience
+    <td>
+      <ul>
+        <li>Above
+        <li><a href="https://github.com/tc39/test262">Test262</a> acceptance tests have been written for mainline usage scenarios, and merged
+        <li>An in-depth implementation has been prototyped which pass most acceptance tests
+        <li>Implementation(s) in build tools or behind a flag has led to some realistic programmer feedback.
+      </ul>
+    </td>
+    <td>The proposal is significantly solidified based on some usage and feedback
+    <td>Semi-final: Most changes as a result of implementation experience are integrated
+    <td>Limited: only those deemed critical based on implementation experience
+    <td>Spec compliant
+  </tr>
+  <tr>
     <td>4
     <td>Finished
     <td>Indicate that the addition is ready for inclusion in the formal ECMAScript standard
     <td>
       <ul>
         <li>Above
-        <li><a href="https://github.com/tc39/test262">Test262</a> acceptance tests have been written for mainline usage scenarios, and merged
         <li>Two compatible implementations which pass the acceptance tests
         <li>Significant in-the-field experience with shipping implementations, such as that provided by two independent VMs
         <li>A pull request has been sent to <a href="https://github.com/tc39/ecma262">tc39/ecma262</a> with the integrated spec text


### PR DESCRIPTION
This proposal attempts to solve a few problems with the current stage model:
- As a committee, we don't agree on what stage advancement means,
  particularly for reaching Stage 4. In the September 2017 TC39 meeting,
  one proposal reached Stage 4 for having one implementation behind a
  flag and another shipping in a "nightly" version of a browser, while
  another was blocked from Stage 4 even though it was shipping in two
  nightly versions, .
- Some implementations, both browsers and infrastructure, prefer to not
  release unflagged/without plugins until a proposal reaches Stage 4, to
  avoid dealing with instability and uncertainty in Stage 3 features.
- The gap between Stage 3 and Stage 4 is pretty large; many
  implementations wait until Stage 3 to review a proposal in detail,
  since from their perspective, prior to Stage 3, things are very
  volatile. However, we don't come to a particular point where we
  recognize that their feedback has been taken into account.

To address these issues, this proposal adds a "Stage 3.5". This stage
is intended to be reached once a significant amount of feedback from
implementation experience has been taken into account. The stage indicates
a greater degree of certainty, without requiring multiple shipping
implementations. With the addition of this intermediate stage, it's hoped
that stability can be communicated while taking off pressure to land in
the main specification, allowing the more conservative interpretations
of Stage 4 to not take away a signal from the committee for relative
stability of the proposal.

This stage isn't meant to be an extra barrier for anybody, but rather
a tool for champions to use when they feel appropriate. Stage 3.5
requirements are a subset of Stage 4 requirements, and it would still
be fine to go straight from 3 to 4, but 3.5 gives some intermediate
recognition of status.