### PR TITLE
Define sufficient in-the-field experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,3 +181,7 @@
 <h2>Role of the editor</h2>
 
 <p>In-process additions will likely have spec text which is authored by a champion or a committee member other than the editor although in some case the editor may also be a champion with responsibility for specific features. The editor is responsible for the overall structure and coherence of the ECMAScript specification. It is also the role of the editor to provide guidance and feedback to spec text authors so that as an addition matures, the quality and completeness of its specification improves. It is also the role of the editor to integrate additions which have been accepted as “finished” (stage 4) into the a new revision of the specification.
+
+<h2>Significant in-the-field experience</h2>
+
+<p>To reach Stage 4, multiple specification-compliant native implementations are required. A native implementation is one which implements ECMAScript all the way from parsing through execution. Native implementations often face different constraints from other sorts of implementations, such as cross-compilers to earlier versions of the language which do not need to support features such as <code>eval</code>, though other such implementations provide useful feedback for the committee and are encouraged as well. An example of a native implementation with sufficient in-the-field experience is an implementation embedded in a web browser shipped to users in a "preview" mode, such as triggered by downloading a special version of the browser, or an option in preferences.</p>


### PR DESCRIPTION
This patch defines requirements for reaching Stage 4 as being satisfied
by a sufficiently used native implementation, such as a JavaScript engine
in a web browser in a "preview" mode.

This patch does not encode the committee's current policy but
rather defines a new policy.