### PR TITLE
Fix broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
 <h1>The TC39 Process</h1>
 
-<p>The Ecma <a href="http://www.ecma-international.org/memento/TC39.htm">TC39</a> committee is responsible for evolving the ECMAScript programming language and authoring the specification. The committee operates by consensus and has discretion to alter the specification as it sees fit. However, the general process for making changes to the specification is as follows.
+<p>The Ecma <a href="https://www.ecma-international.org/memento/tc39.htm">TC39</a> committee is responsible for evolving the ECMAScript programming language and authoring the specification. The committee operates by consensus and has discretion to alter the specification as it sees fit. However, the general process for making changes to the specification is as follows.
 
 <h2>Development</h2>
 

--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
 
 <h2>Input into the process</h2>
 
-<p>Ideas for evolving the ECMAScript language are accepted in any form. Any discussion, idea or proposal for a change or addition which has not been submitted as a formal proposal is considered to be a “strawman” (stage 0) and has no acceptance requirements. Such submissions must either come from members of TC39 or from non-members who have <a href="http://www.ecma-international.org/memento/register_TC39_Royalty_Free_Task_Group.php">registered</a> via Ecma International.
+<p>Ideas for evolving the ECMAScript language are accepted in any form. Any discussion, idea or proposal for a change or addition which has not been submitted as a formal proposal is considered to be a “strawman” (stage 0) and has no acceptance requirements. Such submissions must either come from members of TC39 or from non-members who have <a href="https://tc39.github.io/agreements/contributor">registered</a> via Ecma International.
 
 <h2>Spec revisions and scheduling</h2>
 


### PR DESCRIPTION
For the member registration link, I wasn't too sure what the link was originally pointing to, so I updated the `href` to point to the main 'join' page.