### PR TITLE
Document repository transfers

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,15 @@
 
 <p>The Ecma <a href="https://www.ecma-international.org/memento/tc39.htm">TC39</a> committee is responsible for evolving the ECMAScript programming language and authoring the specification. The committee operates by consensus and has discretion to alter the specification as it sees fit. However, the general process for making changes to the specification is as follows.
 
-<h2>Development</h2>
+<h2>Input into the process</h2>
+
+<p>Ideas for evolving the ECMAScript language are accepted in any form. Any discussion, idea, or proposal for a change or addition which has not been submitted as a formal proposal is considered to be a “strawman” (stage 0) and has no acceptance requirements. Such submissions must either come from TC39 delegates or from non-delegates who have <a href="https://tc39.github.io/agreements/contributor">registered</a> via Ecma International.
+
+<h2>Stages</h2>
 
 <p>Changes to the language are developed by way of a process which provides guidelines for evolving an addition from an idea to a fully specified feature, complete with acceptance tests and multiple implementations. There are five stages: a strawperson stage, and 4 “maturity” stages. The TC39 committee must approve acceptance for each stage.
+
+<p>Proposals at stage 1 and beyond should be owned by the TC39 committee. Upon proposal acceptance, any externally-owned repositories should be transferred by following the <a href="https://github.com/tc39/proposals#onboarding-existing-proposals">onboarding instructions</a>.
 
 <table>
   <caption>ECMAScript Proposal Stages</caption>


### PR DESCRIPTION
Transfer of repositories to TC39 should be documented as part of the proposal process.