### PR TITLE
Explicitly require a public repository for Stage 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
         <li>High-level API
         <li>Discussion of key algorithms, abstractions and semantics
         <li>Identification of potential “cross-cutting” concerns and implementation challenges/complexity
+        <li>A publicly available repository for the proposal that captures the above requirements
       </ul>
     </td>
     <td>The committee expects to devote time to examining the problem space, solutions and cross-cutting concerns


### PR DESCRIPTION
Stage 1 already had various entrance criteria (such as prose outlining the problem, the shape of the solution, examples of usage, the high-level API, etc.), which in practice are expected to be made accessible through a publicly available repository.

This patch explicitly makes the repository a requirement for Stage 1 advancement, resolving the following issues:

- https://github.com/tc39/process-document/issues/24
- https://github.com/tc39/process-document/issues/25
- https://github.com/tc39/agendas/issues/722