### PR TITLE
Remove harmful stage 1 polyfill recommendation

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     </td>
     <td>None
     <td>Major
-    <td>Polyfills / demos
+    <td>Reference implemnentations / demos
   </tr>
   <tr>
     <td>2
@@ -110,7 +110,7 @@
     <td>The solution is complete and no further work is possible without implementation experience, significant usage and external feedback.
     <td>Complete: all semantics, syntax and API are completed described
     <td>Limited: only those deemed critical based on implementation experience
-    <td>Spec compliant
+    <td>Spec compliant; including polyfills, browsers, and any other implementations
   </tr>
   <tr>
     <td>4

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
     <td>The solution is complete and no further work is possible without implementation experience, significant usage and external feedback.
     <td>Complete: all semantics, syntax and API are completed described
     <td>Limited: only those deemed critical based on implementation experience
-    <td>Spec compliant; including polyfills, browsers, and any other implementations
+    <td>Spec-compliant polyfills, engines, and any other implementations (implementations that modify global built-in objects may be tentatively published)
   </tr>
   <tr>
     <td>4

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     </td>
     <td>None
     <td>Major
-    <td>Reference implemnentations / demos
+   <td>Demos and experimental reference implementations (implementations that modify global built-in objects should not be published as libraries or used in production-deployed code; implementations that do not modify global built-in objects may be published)
   </tr>
   <tr>
     <td>2


### PR DESCRIPTION
It seems that this document is inadvertently recommending that folks publish polyfills in stage 1, which is incredibly dangerous for web compat, rather than in stage 3, which is the appropriate time.

This PR does not change any stage advancement criteria; in spec lingo, it is editorial, not normative.