### PR TITLE
fix: broken link on TC39 page

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
 <h1>The TC39 Process</h1>
 
-<p>The Ecma <a href="https://www.ecma-international.org/memento/tc39.htm">TC39</a> committee is responsible for evolving the ECMAScript programming language and authoring the specification. The committee operates by consensus and has discretion to alter the specification as it sees fit. However, the general process for making changes to the specification is as follows.
+<p>The Ecma <a href="https://ecma-international.org/technical-committees/tc39/">TC39</a> committee is responsible for evolving the ECMAScript programming language and authoring the specification. The committee operates by consensus and has discretion to alter the specification as it sees fit. However, the general process for making changes to the specification is as follows.
 
 <h2>Stages</h2>
 


### PR DESCRIPTION
This PR fix a broken link on process-document page

<img width="1202" alt="Capture d’écran 2024-02-08 à 17 57 47" src="https://github.com/tc39/process-document/assets/2315749/16ab3da9-be67-4303-9367-2678d9152551">
