### PR TITLE
even out the column widths in the stages table

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,14 @@
     border-collapse: collapse;
   }
 
+  #stages {
+    table-layout: fixed;
+    width: 100%;
+  }
+  #stages th:first-child {
+    width: 55px;
+  }
+
   ul {
     padding: 0 1.5em;
     margin: 0;
@@ -34,7 +42,7 @@
 
 <p>Proposals at stage 1 and beyond should be owned by the TC39 committee. Upon proposal acceptance, any externally-owned repositories should be transferred by following the <a href="https://github.com/tc39/proposals#onboarding-existing-proposals">onboarding instructions</a>.
 
-<table>
+<table id="stages">
   <caption>ECMAScript Proposal Stages</caption>
 
   <thead>


### PR DESCRIPTION
This makes for better reading on a wide display.

before:

![image](https://github.com/tc39/process-document/assets/218840/441fdc3c-6cd5-4972-837b-ef5260527942)

after:

![image](https://github.com/tc39/process-document/assets/218840/54740e67-192a-47e6-ba70-7134e625b07b)
