### PR TITLE
♿️ a11y - text spacing and alignment fixes, add dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,23 @@
 <style>
   html {
     font-family: sans-serif;
+    font-size: 16px;
+
+    /* WCAG 2.1 - Line height (line spacing) to at least 1.5 times the font size */
+    line-height: 1.6;
+
+    /* WCAG 2.1 - Letter spacing (tracking) to at least 0.12 times the font size */
+    /* letter-spacing: 0.12em; */
+
+    /* WCAG 2.1 - Word spacing to at least 0.16 times the font size */
+    /* word-spacing: 0.16em; */
   }
 
   th, td {
     vertical-align: top;
     border: 1px solid black;
     padding: 0.4em;
+    text-align: left;
   }
 
   table {
@@ -25,9 +36,63 @@
     width: 55px;
   }
 
+  caption {
+    font-weight: bold;
+    margin-bottom: 10px;
+    text-align: left;
+  }
+
+  p {
+    /* WCAG 2.1 - Spacing following paragraphs to at least 2 times the font size */
+    margin-bottom: 2rem;
+  }
+
   ul {
-    padding: 0 1.5em;
+    padding: 0 0 0 1.5rem;
     margin: 0;
+  }
+
+  a:link {
+    color: #5140c4;
+    text-underline-offset: 25%;
+  }
+
+  a:visited {
+    color: #5140c4;
+  }
+
+  a:hover,
+  a:focus {
+    color: indigo;
+    text-decoration: none;
+  }
+
+  a:active {
+    color: #5140c4;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body {
+      background: #21212c;
+      color: lightgrey;
+    }
+
+    a:link {
+      color: #9a78dd;
+    }
+
+    a:visited {
+      color: #9a78dd;
+    }
+
+    a:hover,
+    a:focus {
+      color: lightgrey;
+    }
+
+    th, td {
+      border: 1px solid lightgrey;
+    }
   }
 </style>
 


### PR DESCRIPTION
## issues addressed

- WCAG Success Criterion 1.4.12 Text Spacing
  - note, two of the rules for compliance are currently commented out.  CSS letter spacing and word spacing makes the text look quite weird
- ~converted the stage table to regular layout.~ "[Tables must not be used as layout aids.](https://html.spec.whatwg.org/multipage/tables.html#the-table-element:~:text=Tables%20must%20not%20be%20used%20as%20layout%20aids.)"
  - also they are not great for a11y and small displays
  - this change has been backed out.  (see comments below)
- added dark mode for those who celebrate
- there are no changes to text content

### befores and afters

![Screenshot 2025-01-22 at 4 01 57 PM](https://github.com/user-attachments/assets/8e15ec88-4f0d-491a-a9dc-cef1c97869bc)

### dark mode

![Screenshot 2025-01-22 at 4 02 23 PM](https://github.com/user-attachments/assets/efcce4cc-4701-48d5-90a1-41c4b3d9834f)

### validations

![Screenshot 2025-01-22 at 3 13 02 PM](https://github.com/user-attachments/assets/725bcb0c-c8e2-446c-9631-b19079555a3a)

![Screenshot 2025-01-22 at 3 30 08 PM](https://github.com/user-attachments/assets/ff020dd0-d67f-422f-8ce6-06f11c72a48d)
